### PR TITLE
list_files_in_directory() should be able to only return images

### DIFF
--- a/util/list_files_in_directory.m
+++ b/util/list_files_in_directory.m
@@ -8,8 +8,9 @@ function files = list_files_in_directory(dirpath, extensions)
 % - if it is a string, only return files with this extension
 % - if it is not given, return all files
 %
-% NOTE: this can be used with convert_to_I, as follows >> files =
-% list_files_in_directory('~/myimages/'); >> imagesc(convert_to_I(files{10}))
+% NOTE: this can be used with convert_to_I, as follows:
+% >> files = % list_files_in_directory('~/myimages/');
+% >> imagesc(convert_to_I(files{10}))
 
 if ~isstr(dirpath)
   fprintf(1,'list_files_in_directory: Warning, not a directory\n');

--- a/util/list_files_in_directory.m
+++ b/util/list_files_in_directory.m
@@ -1,24 +1,36 @@
-function files = list_files_in_directory(dirpath)
-% Given a directory, list all files inside the directory and create
-% a cell array of strings, where each string is the file location
-% NOTE: this can be used with convert_to_I, as follows
-% Examples:
-%  >> files = list_files_in_directory('~/myimages/');
-%  >> imagesc(convert_to_I(files{10}))
+function files = list_files_in_directory(dirpath, extensions)
+% Given a directory, list all files inside the directory and create a cell
+% array of strings, where each string is the file location
 %
-% In the case where there are non-image files in the directory
-%  >> files = list_files_in_directory('~/myimages/*jpg');
-%  >> imagesc(convert_to_I(files{10}))
+% extensions is optional and a cell array of extensions that you want this
+% function to return. If given, any file with an extension not listed in this
+% cell array will be not be returned. If extensions is true, then only images
+% will be returned.
+%
+% NOTE: this can be used with convert_to_I, as follows >> files =
+% list_files_in_directory('~/myimages/'); >> imagesc(convert_to_I(files{10}))
 
 if ~isstr(dirpath)
   fprintf(1,'list_files_in_directory: Warning, not a directory\n');
   files = {};
   return;
 end
-[basedir, other, other2] = fileparts(dirpath);
 
 files = dir(dirpath);
 isdirs = arrayfun(@(x)x.isdir,files);
 files = files(~isdirs);
 files = {files.name};
-files = cellfun2(@(x)[basedir '/' x],files);
+files = cellfun2(@(x)[dirpath '/' x],files);
+
+if exist('extensions', 'var'),
+  if ~iscell(extensions),
+    extensions = {'.jpg', '.png', '.gif', '.ppm', '.tif', '.jpeg'};
+  end
+  ext = cellfun2(@(x)get_extension(x), files);
+  ext = cellfun2(@(x)any(strcmp(x, extensions)), ext);
+  ext = arrayfun(@(x)x{1}, ext);
+  files = files(find(ext));
+end
+
+function extension = get_extension(file)
+[~,~,extension] = fileparts(file);

--- a/util/list_files_in_directory.m
+++ b/util/list_files_in_directory.m
@@ -34,7 +34,7 @@ if exist('extensions', 'var'),
     end
   end
   ext = cellfun2(@(x)get_extension(x), files);
-  ext = cellfun2(@(x)any(strcmp(x, extensions)), ext);
+  ext = cellfun2(@(x)any(strcmpi(x, extensions)), ext);
   ext = arrayfun(@(x)x{1}, ext);
   files = files(find(ext));
 end

--- a/util/list_files_in_directory.m
+++ b/util/list_files_in_directory.m
@@ -2,10 +2,11 @@ function files = list_files_in_directory(dirpath, extensions)
 % Given a directory, list all files inside the directory and create a cell
 % array of strings, where each string is the file location
 %
-% extensions is optional and a cell array of extensions that you want this
-% function to return. If given, any file with an extension not listed in this
-% cell array will be not be returned. If extensions is true, then only images
-% will be returned.
+% extensions is optional and can take a variety of types:
+% - if it is a cell array, only return files with extensions in this array
+% - if it is the string 'images', only return images
+% - if it is a string, only return files with this extension
+% - if it is not given, return all files
 %
 % NOTE: this can be used with convert_to_I, as follows >> files =
 % list_files_in_directory('~/myimages/'); >> imagesc(convert_to_I(files{10}))
@@ -23,8 +24,14 @@ files = {files.name};
 files = cellfun2(@(x)[dirpath '/' x],files);
 
 if exist('extensions', 'var'),
-  if ~iscell(extensions),
-    extensions = {'.jpg', '.png', '.gif', '.ppm', '.tif', '.jpeg'};
+  if isstr(extensions),
+    if strcmpi(extensions, 'images') || strcmpi(extensions, 'image'),
+      extensions = {'.jpg', '.png', '.gif', '.ppm', '.tif', '.jpeg'};
+    elseif strcmpi(extensions, 'videos') || strcmpi(extensions, 'video'),
+      extensions = {'.mp4', '.mov', '.avi', '.ogv', '.wmv'};
+    else,
+      extensions = {extensions};
+    end
   end
   ext = cellfun2(@(x)get_extension(x), files);
   ext = cellfun2(@(x)any(strcmp(x, extensions)), ext);


### PR DESCRIPTION
Since this is a computer vision toolkit, list_files_in_directory() should be able to only return images. This commit introduces an optional parameter that:
- if it is a cell array, only return files with extensions in this arra
- if it is the string 'images', only return images  
- if it is the string 'videos', only return videos  
- if it is a string, only return files with this extension  
- if it is not given, return all files  

(Also, I wanted to see what 'pull request' did)
