### PR TITLE
BUGFIX. Unused variable removed, that caused quadratic running time o…

### DIFF
--- a/internal/esvm_mine_negatives.m
+++ b/internal/esvm_mine_negatives.m
@@ -108,7 +108,7 @@ for i = 1:length(mining_queue)
   if supersize > 0
     addon=sprintf(', max = %.3f',max(cellfun(@(x)max_or_this(x,-1000),scores)));
   end
-  total = sum(cellfun(@(x)x.num_visited,mining_queue));
+
   fprintf(1,'Found %04d windows, image:%05d (#seen=%05d/%05d%s)\n',...
           supersize, index, ...
           length(imageset)-length(mining_queue)+i, length(imageset), addon);

--- a/internal/esvm_mine_negatives.m
+++ b/internal/esvm_mine_negatives.m
@@ -214,17 +214,10 @@ end
 function mining_queue = update_mq_onepass(mining_queue, violating_images, ...
                                            empty_images)
 
-%% Take the violating images and remove them from queue
-mover_ids = find(cellfun(@(x)ismember(x.index,violating_images), ...
-                         mining_queue));
-
+%% Take the violating and empty images and remove them from queue
+mover_ids = 1:(length(violating_images) + length(empty_images));
 mining_queue(mover_ids) = [];
 
-%% We now take the empty images and remove them from queue
-mover_ids = find(cellfun(@(x)ismember(x.index,empty_images), ...
-                         mining_queue));
-
-mining_queue(mover_ids) = [];
 
 function mining_queue = update_mq_front_violators(mining_queue,...
                                                   violating_images, ...


### PR DESCRIPTION
1. Fixed BUG, that caused looping over all dataset every time we applied SVM to an image during mining of negatives. 
   Running time improved from quadratic to linear.
2. Optimized  method for ipdating mining queue _update_mq_onepass_. 
   No need to loop through all the queue two times to find elements to delete, because in 'onepass' mode we loop images iteratively one-by-one. 
